### PR TITLE
Added Auth to CodeAnayler page for logged in users

### DIFF
--- a/CodeWhispererAI/Controllers/AnalysisController.cs
+++ b/CodeWhispererAI/Controllers/AnalysisController.cs
@@ -4,9 +4,11 @@ using CodeWhispererAI.DataAccess;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CodeWhispererAI.Controllers
 {
+    [Authorize]
     public class AnalysisController : Controller
     {
         private readonly UserManager<ApplicationUser> _userManager;

--- a/CodeWhispererAI/Program.cs
+++ b/CodeWhispererAI/Program.cs
@@ -25,6 +25,12 @@ try
         .AddEntityFrameworkStores<CodeWhispererAIContext>()
         .AddDefaultTokenProviders();
 
+    builder.Services.ConfigureApplicationCookie(options =>
+    {
+        // Set the login path
+        options.LoginPath = "/Identity/Account/Login"; 
+    });
+
     builder.Services.AddDbContext<CodeWhispererAIContext>(
             options =>
                 options


### PR DESCRIPTION
To prevent users from saving thier code snippets to a null accounts because they arnt logged in I made the whole analysis controller for logged in users. 